### PR TITLE
bugfix/accurics_remediation_9159155478794474 - Auto Generated Pull Request From Accurics

### DIFF
--- a/ec2/main.tf
+++ b/ec2/main.tf
@@ -49,6 +49,7 @@ resource "aws_instance" "node" {
     http_endpoint = "disabled"
     http_tokens   = "required"
   }
+  iam_instance_profile = "arn:aws:iam::438071034310:role/TenableReadOnlyTrustRole"
 }
 
 # Create and assosiate an Elastic IP


### PR DESCRIPTION
IAM roles can only be associated at the launch of an instance. To remediate an instance to add it to a role you must create a new instance.

If the instance has no external dependencies on its current private ip or public addresses are elastic IPs:

1. In AWS IAM create a new role. Assign a permissions policy if needed permissions are already known.
2. In the AWS console launch a new instance with identical settings to the existing instance, and ensure that the newly created role is selected.
3. Shutdown both the existing instance and the new instance.
4. Detach disks from both instances.
5. Attach the existing instance disks to the new instance.
6. Boot the new instance and you should have the same machine, but with the associated role.

**Note:** if your environment has dependencies on a dynamically assigned PRIVATE IP address you can create an AMI from the existing instance, destroy the old one and then when launching from the AMI, manually assign the previous private IP address.

**Note: **if your environment has dependencies on a dynamically assigned PUBLIC IP address there is not a way ensure the address is retained and assign an instance role. Dependencies on dynamically assigned public IP addresses are a bad practice and, if possible, you may wish to rebuild the instance with a new elastic IP address and make the investment to remediate affected systems while assigning the system to a role.